### PR TITLE
Make xdebug working

### DIFF
--- a/4.1/default.vcl
+++ b/4.1/default.vcl
@@ -23,16 +23,6 @@ sub vcl_recv {
     # Protecting against the HTTPOXY CGI vulnerability.
     unset req.http.proxy;
 
-    # Add an X-Forwarded-For header with the client IP address.
-    if (req.restarts == 0) {
-        if (req.http.X-Forwarded-For) {
-            set req.http.X-Forwarded-For = req.http.X-Forwarded-For + ", " + client.ip;
-        }
-        else {
-            set req.http.X-Forwarded-For = client.ip;
-        }
-    }
-
     # Only allow PURGE requests from IP addresses in the 'purge' ACL.
     if (req.method == "PURGE") {
         if (!client.ip ~ purge) {
@@ -122,7 +112,7 @@ sub vcl_recv {
         #    cookie string.
         set req.http.Cookie = ";" + req.http.Cookie;
         set req.http.Cookie = regsuball(req.http.Cookie, "; +", ";");
-        set req.http.Cookie = regsuball(req.http.Cookie, ";(SESS[a-z0-9]+|SSESS[a-z0-9]+|NO_CACHE)=", "; \1=");
+        set req.http.Cookie = regsuball(req.http.Cookie, ";(SESS[a-z0-9]+|SSESS[a-z0-9]+|NO_CACHE|XDEBUG_SESSION)=", "; \1=");
         set req.http.Cookie = regsuball(req.http.Cookie, ";[^ ][^;]*", "");
         set req.http.Cookie = regsuball(req.http.Cookie, "^[; ]+|[; ]+$", "");
 

--- a/5.1/default.vcl
+++ b/5.1/default.vcl
@@ -23,16 +23,6 @@ sub vcl_recv {
     # Protecting against the HTTPOXY CGI vulnerability.
     unset req.http.proxy;
 
-    # Add an X-Forwarded-For header with the client IP address.
-    if (req.restarts == 0) {
-        if (req.http.X-Forwarded-For) {
-            set req.http.X-Forwarded-For = req.http.X-Forwarded-For + ", " + client.ip;
-        }
-        else {
-            set req.http.X-Forwarded-For = client.ip;
-        }
-    }
-
     # Only allow PURGE requests from IP addresses in the 'purge' ACL.
     if (req.method == "PURGE") {
         if (!client.ip ~ purge) {
@@ -122,7 +112,7 @@ sub vcl_recv {
         #    cookie string.
         set req.http.Cookie = ";" + req.http.Cookie;
         set req.http.Cookie = regsuball(req.http.Cookie, "; +", ";");
-        set req.http.Cookie = regsuball(req.http.Cookie, ";(SESS[a-z0-9]+|SSESS[a-z0-9]+|NO_CACHE)=", "; \1=");
+        set req.http.Cookie = regsuball(req.http.Cookie, ";(SESS[a-z0-9]+|SSESS[a-z0-9]+|NO_CACHE|XDEBUG_SESSION)=", "; \1=");
         set req.http.Cookie = regsuball(req.http.Cookie, ";[^ ][^;]*", "");
         set req.http.Cookie = regsuball(req.http.Cookie, "^[; ]+|[; ]+$", "");
 


### PR DESCRIPTION
Related to https://gitlab.the-s-team.com/Skilld/processes/issues/23

Basically, the PR consists of 2 parts:
- pass on XDEBUG_SESSION cookie
- remove X-Forwarded-For header logic from vcl_recv

XDEBUG_SESSION cookie is needed to activate xdebug on PHP side.

Removal of X-Forwarded-For logic is needed so that PHP receives one correct value there to connect back to. Basically, this logic was added into Varnish itself, at least in 4.0+ - https://github.com/varnishcache/varnish-cache/blob/4.0/bin/varnishd/cache/cache_req_fsm.c#L724 - and is not needed in the default.vcl as when we have it we will end up with the same value concatenated with delimiter ", ". Most probably this piece of vcl config was just copy/pasted from configs for older versions of Varnish.
Then this concatenated value hits php with xdebug and xdebug doesn't explode it - it just tries to connect to the value it gets in the X-Forwarded-For header and fails.